### PR TITLE
docs: add comprehensive wiki documentation

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -1,0 +1,34 @@
+name: Sync Wiki
+
+on:
+  push:
+    branches: [main]
+    paths: ['wiki/**']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync-wiki:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Sync wiki
+        run: |
+          git clone https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git gh-wiki
+
+          cd gh-wiki
+
+          git config --global --add safe.directory "$(pwd)"
+          git config user.name "Oleksii Lisikh"
+          git config user.email "alisiikh@gmail.com"
+
+          rm -rf *
+          cp -r ../wiki/* .
+
+          git add .
+          git commit -m "action: wiki sync" || echo "No changes to commit"
+          git push

--- a/wiki/1. Installation.md
+++ b/wiki/1. Installation.md
@@ -1,0 +1,175 @@
+# Installation
+
+This guide covers installing and configuring `neotest-scala` for Neovim.
+
+## Requirements
+
+| Requirement | Version | Purpose |
+|-------------|---------|---------|
+| **Neovim** | 0.8+ | Core editor with LSP and Treesitter support |
+| **neotest** | Latest | Test runner framework |
+| **nvim-metals** | Latest | Scala LSP server for project metadata |
+| **sbt** | 1.x | Build tool for running tests |
+| **Treesitter Scala** | Latest | Scala parser for test discovery |
+
+### Verifying Requirements
+
+```vim
+" Check Neovim version
+:version
+" Should show v0.8.0 or higher
+
+" Check if Treesitter Scala parser is installed
+:TSInstallInfo
+" Should show scala installed
+
+" Check if Metals is running
+:LspInfo
+" Should show metals attached to Scala buffers
+```
+
+## Installation
+
+### lazy.nvim (Recommended)
+
+```lua
+{
+  'nvim-neotest/neotest',
+  dependencies = {
+    'nvim-neotest/neotest-plenary',
+    'olisikh/neotest-scala',
+  },
+}
+```
+
+With custom configuration:
+
+```lua
+{
+  'nvim-neotest/neotest',
+  dependencies = {
+    'nvim-neotest/neotest-plenary',
+    'olisikh/neotest-scala',
+  },
+  config = function()
+    require("neotest").setup({
+      adapters = {
+        require("neotest-scala")({
+          args = { "--no-colors" },
+        })
+      }
+    })
+  end,
+}
+```
+
+### packer.nvim
+
+```lua
+use {
+  'nvim-neotest/neotest',
+  requires = {
+    'nvim-neotest/neotest-plenary',
+    'olisikh/neotest-scala',
+  },
+  config = function()
+    require("neotest").setup({
+      adapters = {
+        require("neotest-scala")
+      }
+    })
+  end,
+}
+```
+
+### vim-plug
+
+```vim
+" Required dependencies
+Plug 'nvim-neotest/neotest'
+Plug 'nvim-neotest/neotest-plenary'
+Plug 'olisikh/neotest-scala'
+```
+
+Then add to your `init.vim` or a separate Lua config file:
+
+```lua
+require("neotest").setup({
+  adapters = {
+    require("neotest-scala")
+  }
+})
+```
+
+## Post-Install Setup
+
+### 1. Install Treesitter Scala Parser
+
+```vim
+:TSInstall scala
+```
+
+### 2. Configure Metals
+
+`neotest-scala` requires Metals to be running and attached to your Scala buffers. If you're using `nvim-metals`, ensure it's properly configured:
+
+```lua
+local metals_config = require('metals').bare_config()
+
+metals_config.settings = {
+  showImplicitArguments = true,
+  showImplicitConversionsAndClasses = true,
+  showInferredType = true,
+}
+
+-- Autocommand to start Metals
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = { "scala", "sbt" },
+  callback = function()
+    require("metals").initialize_or_attach(metals_config)
+  end,
+  group = vim.api.nvim_create_augroup("nvim-metals", { clear = true }),
+})
+```
+
+### 3. Verify Installation
+
+1. Open a Scala test file in a project with Metals configured
+2. Wait for Metals to initialize (check `:LspInfo`)
+3. Run a test with Neotest:
+
+```vim
+:Neotest run
+```
+
+You should see the test output in a floating window or the Neotest summary panel.
+
+## Basic Usage
+
+Once installed, you can use Neotest commands:
+
+| Command | Description |
+|---------|-------------|
+| `:Neotest run` | Run the nearest test to the cursor |
+| `:Neotest run file` | Run all tests in the current file |
+| `:Neotest run directory` | Run all tests in a directory |
+| `:Neotest stop` | Stop running tests |
+| `:Neotest summary` | Toggle the test summary panel |
+| `:Neotest output` | Show output for a test |
+| `:Neotest output-panel` | Toggle the output panel |
+
+### Keymaps Example
+
+```lua
+vim.keymap.set('n', '<leader>tt', function() require('neotest').run.run() end)
+vim.keymap.set('n', '<leader>tf', function() require('neotest').run.run(vim.fn.expand('%')) end)
+vim.keymap.set('n', '<leader>ts', function() require('neotest').summary.toggle() end)
+vim.keymap.set('n', '<leader>to', function() require('neotest').output.open({ enter = true }) end)
+vim.keymap.set('n', '<leader>td', function() require('neotest').run.run({ strategy = 'dap' }) end)
+```
+
+## Next Steps
+
+- [[Configuration|2.-Configuration]] — Customize args and options
+- [[Supported Test Libraries|3.-Supported-Test-Libraries]] — Learn about supported test libraries
+- [[Debugging]] — Set up test debugging with nvim-dap

--- a/wiki/2. Configuration.md
+++ b/wiki/2. Configuration.md
@@ -1,0 +1,232 @@
+# Configuration
+
+This page documents all configuration options for `neotest-scala`.
+
+## Quick Reference
+
+```lua
+require("neotest").setup({
+  adapters = {
+    require("neotest-scala")({
+      -- Static args passed to sbt
+      args = { "--no-colors" },
+      
+      -- Or dynamic args based on context
+      args = function(context)
+        -- context contains: path, framework, project_name, build_target_info
+        return { "-v" }
+      end,
+    })
+  }
+})
+```
+
+---
+
+## Configuration Options
+
+### `args`
+
+Arguments to pass to `sbt` when running tests.
+
+| Type | Default | Description |
+|------|---------|-------------|
+| `string[]` or `function` | `{}` | Extra args for the sbt command |
+
+#### Static Args
+
+Pass a fixed list of arguments:
+
+```lua
+require("neotest-scala")({
+  args = { "--no-colors", "-v" }
+})
+```
+
+#### Dynamic Args
+
+Use a function for context-aware arguments:
+
+```lua
+require("neotest-scala")({
+  args = function(context)
+    -- context is a table with:
+    --   path              - full path to the test file
+    --   framework         - detected test library name (e.g., "munit", "scalatest")
+    --   project_name      - sbt project name
+    --   build_target_info - Metals build target information
+    
+    -- Example: verbose output for zio-test only
+    if context.framework == "zio-test" then
+      return { "-v" }
+    end
+    
+    return {}
+  end
+})
+```
+
+#### Context Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `path` | `string` | Full path to the project root |
+| `framework` | `string` | Detected test library: `"utest"`, `"munit"`, `"scalatest"`, `"specs2"`, or `"zio-test"` |
+| `project_name` | `string` | sbt project name (without `-test` suffix) |
+| `build_target_info` | `table` | Raw Metals build target data |
+
+---
+
+## How Test Commands Are Built
+
+neotest-scala builds sbt commands based on what you're running:
+
+### Run All Tests in Project
+
+```bash
+sbt <project>/test
+```
+
+### Run Tests in a Specific Class
+
+```bash
+sbt <project>/testOnly com.example.MyTestSuite
+```
+
+### Run a Single Test
+
+The command varies by test library:
+
+| Library | Single Test Syntax |
+|---------|-------------------|
+| ScalaTest | `sbt <project>/testOnly com.example.MyTest -- -z "test name"` |
+| munit | `sbt <project>/testOnly -- "com.example.MyTestSuite.test name"` |
+| utest | `sbt <project>/testOnly -- "com.example.MyTestSuite.test name"` |
+| zio-test | `sbt <project>/testOnly com.example.MyTest -- -t "test name"` |
+| specs2 | `sbt <project>/testOnly com.example.MyTest` (single test limited) |
+
+> **Note**: specs2 has limited support for running individual tests due to framework limitations.
+
+---
+
+## Test File Detection
+
+Files are detected as test files based on naming conventions:
+
+```lua
+-- Files matching these patterns (case-insensitive) are test files:
+"*test*.scala"   -- e.g., MyTest.scala, TestSpec.scala
+"*spec*.scala"   -- e.g., UserSpec.scala, SpecHelper.scala (also matched)
+"*suite*.scala"  -- e.g., TestSuite.scala
+```
+
+---
+
+## Test Discovery with Treesitter
+
+neotest-scala uses Treesitter queries to discover tests. The following patterns are detected:
+
+### Object/Class Definitions
+
+```scala
+// Detected as test namespaces
+object MyTestSuite extends TestSuite { ... }
+class MySpec extends AnyFunSuite { ... }
+```
+
+### Test Definitions
+
+```scala
+// munit, utest, zio-test, ScalaTest FunSuite
+test("my test name") { ... }
+
+// zio-test suiteAll
+suiteAll("my suite") { ... }
+
+// ScalaTest FreeSpec, specs2 mutable.Specification
+"my test name" - { ... }
+"my test name" in { ... }
+"my test name" should { ... }
+"my test name" can { ... }
+"my test name" >> { ... }
+```
+
+---
+
+## Framework Auto-Detection
+
+The adapter automatically detects which test library is in use by examining the project's classpath via Metals:
+
+1. Queries Metals for build target information
+2. Scans classpath JARs for known test library patterns
+3. Falls back to ScalaTest if no library detected
+
+| Library | Detection Pattern |
+|---------|------------------|
+| specs2 | `specs2-core_*.jar` |
+| munit | `munit_*.jar` |
+| scalatest | `scalatest_*.jar` |
+| utest | `utest_*.jar` |
+| zio-test | `zio-test_*.jar` |
+
+---
+
+## Neotest Strategy Configuration
+
+### Integrated Strategy
+
+Run tests in a terminal buffer:
+
+```lua
+require('neotest').run.run({ strategy = 'integrated' })
+```
+
+### DAP Strategy (Debugging)
+
+Run tests with the debugger:
+
+```lua
+require('neotest').run.run({ strategy = 'dap' })
+```
+
+See [[Debugging]] for full debugging setup.
+
+---
+
+## Complete Configuration Example
+
+```lua
+require("neotest").setup({
+  adapters = {
+    require("neotest-scala")({
+      args = function(context)
+        -- Verbose output for CI
+        if os.getenv("CI") then
+          return { "-v", "--no-colors" }
+        end
+        
+        -- Different args by framework
+        if context.framework == "specs2" then
+          return { "--sequential" }
+        end
+        
+        return {}
+      end,
+    })
+  },
+  -- Neotest general config
+  status = { virtual_text = true },
+  output = { open_on_run = true },
+  summary = {
+    open = "botright vsplit | vertical resize 40"
+  },
+})
+```
+
+---
+
+## Related Pages
+
+- [[Installation|1.-Installation]] — Setup and installation
+- [[Supported Test Libraries|3.-Supported-Test-Libraries]] — Test library overview
+- [[Debugging]] — Debugging with nvim-dap

--- a/wiki/3. Supported Test Libraries.md
+++ b/wiki/3. Supported Test Libraries.md
@@ -1,0 +1,273 @@
+# Supported Test Libraries
+
+neotest-scala supports 5 Scala test libraries out of the box.
+
+## Overview
+
+| Library | Style | Single Test Run | Single Test Debug | Learn More |
+|---------|-------|-----------------|-------------------|------------|
+| [ScalaTest](ScalaTest) | BDD, FunSuite, FreeSpec | ✅ | ✅ | [scalatest.org](https://www.scalatest.org/) |
+| [munit](munit) | ScalaTest-style | ✅ | ✅ | [scalameta.org/munit](https://scalameta.org/munit/) |
+| [specs2](specs2) | Specification-based | ⚠️ Limited | ✅ | [etorreborre.github.io/specs2](https://etorreborre.github.io/specs2) |
+| [utest](utest) | Lightweight | ✅ | ❌ | [github.com/com-lihaoyi/utest](https://github.com/com-lihaoyi/utest) |
+| [zio-test](zio-test) | ZIO effects | ✅ | ✅ | [zio.dev/reference/test](https://zio.dev/reference/test) |
+
+---
+
+## Test Syntax Summary
+
+### ScalaTest
+
+Multiple test styles supported:
+
+```scala
+// FunSuite style
+class MySpec extends AnyFunSuite {
+  test("my test") { assert(1 == 1) }
+}
+
+// FreeSpec style
+class MySpec extends AnyFreeSpec {
+  "my feature" - {
+    "should work" in { assert(1 == 1) }
+  }
+}
+```
+
+→ See [[ScalaTest]] for details
+
+### munit
+
+```scala
+class MySuite extends FunSuite {
+  test("my test") {
+    assertEquals(1, 1)
+  }
+}
+```
+
+→ See [[munit]] for details
+
+### specs2
+
+```scala
+class MySpec extends mutable.Specification {
+  "MyFeature" >> {
+    "should work" in {
+      1 mustEqual 1
+    }
+  }
+}
+```
+
+→ See [[specs2]] for details
+
+### utest
+
+```scala
+object MyTests extends TestSuite {
+  val tests = Tests {
+    test("my test") {
+      1 ==> 1
+    }
+  }
+}
+```
+
+→ See [[utest]] for details
+
+### zio-test
+
+```scala
+object MySpec extends ZIOSpecDefault {
+  def spec = suite("my suite")(
+    test("my test") {
+      assertTrue(1 == 1)
+    }
+  )
+}
+```
+
+→ See [[zio-test]] for details
+
+---
+
+## Feature Comparison
+
+### Single Test Execution
+
+| Library | Run Single Test | Command Syntax |
+|---------|-----------------|----------------|
+| ScalaTest | ✅ | `-z "test name"` |
+| munit | ✅ | Test path selector |
+| specs2 | ⚠️ | Limited (runs full spec) |
+| utest | ✅ | Test path selector |
+| zio-test | ✅ | `-t "test name"` |
+
+### Debugging Support
+
+| Library | Debug Single Test | Notes |
+|---------|-------------------|-------|
+| ScalaTest | ✅ | Full support via `TestSelector` |
+| munit | ✅ | Full support via `TestSelector` |
+| specs2 | ✅ | Full support via `TestSelector` |
+| utest | ❌ | Does not implement `sbt.testing.TestSelector` |
+| zio-test | ✅ | Full support via `TestSelector` |
+
+> **Note**: utest cannot debug individual tests because it doesn't implement sbt's `TestSelector` interface. You can still debug at the suite/class level.
+
+### Nested Test Support
+
+| Library | Nested Tests | Detection |
+|---------|--------------|-----------|
+| ScalaTest FreeSpec | ✅ | `in`, `-` operators |
+| munit | ✅ | Nested `test()` calls |
+| specs2 | ✅ | `>>`, `in` operators |
+| utest | ✅ | Nested `test()` blocks |
+| zio-test | ✅ | Nested `suite()` calls |
+
+---
+
+## Framework Detection
+
+neotest-scala automatically detects the test library in use by scanning your project's classpath via Metals:
+
+```scala
+// Detected by JAR name patterns:
+"specs2-core_*.jar"   → specs2
+"munit_*.jar"         → munit  
+"scalatest_*.jar"     → ScalaTest
+"utest_*.jar"         → utest
+"zio-test_*.jar"      → zio-test
+```
+
+If no library is detected, ScalaTest is used as the default.
+
+---
+
+## Test File Naming
+
+Test files are detected by naming convention (case-insensitive):
+
+| Pattern | Example Files |
+|---------|---------------|
+| `*Test.scala` | `UserTest.scala`, `IntegrationTest.scala` |
+| `*Spec.scala` | `UserSpec.scala`, `APISpec.scala` |
+| `*Suite.scala` | `TestSuite.scala`, `MyTestSuite.scala` |
+
+---
+
+## Quick Start by Library
+
+### ScalaTest
+
+```scala
+// build.sbt
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.18" % Test
+```
+
+```scala
+// src/test/scala/MySpec.scala
+import org.scalatest.funsuite.AnyFunSuite
+
+class MySpec extends AnyFunSuite {
+  test("example") {
+    assert(1 + 1 === 2)
+  }
+}
+```
+
+### munit
+
+```scala
+// build.sbt
+libraryDependencies += "org.scalameta" %% "munit" % "1.0.0" % Test
+```
+
+```scala
+// src/test/scala/MySuite.scala
+class MySuite extends munit.FunSuite {
+  test("example") {
+    assertEquals(1 + 1, 2)
+  }
+}
+```
+
+### specs2
+
+```scala
+// build.sbt
+libraryDependencies += "org.specs2" %% "specs2-core" % "4.20.3" % Test
+```
+
+```scala
+// src/test/scala/MySpec.scala
+import org.specs2.mutable.Specification
+
+class MySpec extends Specification {
+  "My feature" >> {
+    "should work" >> {
+      1 mustEqual 1
+    }
+  }
+}
+```
+
+### utest
+
+```scala
+// build.sbt
+libraryDependencies += "com.lihaoyi" %% "utest" % "0.8.3" % Test
+testFrameworks += new TestFramework("utest.runner.Framework")
+```
+
+```scala
+// src/test/scala/MyTests.scala
+import utest._
+
+object MyTests extends TestSuite {
+  val tests = Tests {
+    test("example") {
+      1 + 1 ==> 2
+    }
+  }
+}
+```
+
+### zio-test
+
+```scala
+// build.sbt
+libraryDependencies ++= Seq(
+  "dev.zio" %% "zio" % "2.1.0",
+  "dev.zio" %% "zio-test" % "2.1.0" % Test,
+  "dev.zio" %% "zio-test-sbt" % "2.1.0" % Test
+)
+testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
+```
+
+```scala
+// src/test/scala/MySpec.scala
+import zio.test._
+import zio.test.Assertion._
+
+object MySpec extends ZIOSpecDefault {
+  def spec = suite("example")(
+    test("addition works") {
+      assertTrue(1 + 1 == 2)
+    }
+  )
+}
+```
+
+---
+
+## Related Pages
+
+- [[Configuration|2.-Configuration]] — Configure args and options
+- [[ScalaTest]] — ScalaTest details
+- [[munit]] — munit details  
+- [[specs2]] — specs2 details
+- [[utest]] — utest details
+- [[zio-test]] — zio-test details
+- [[Debugging]] — Debug test setup

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -1,0 +1,251 @@
+# Contributing
+
+Contributions to neotest-scala are welcome! This page covers how to add support for new test libraries or improve existing support.
+
+## Development Setup
+
+### 1. Clone and Setup
+
+```bash
+git clone https://github.com/olisikh/neotest-scala.git
+cd neotest-scala
+```
+
+### 2. Project Structure
+
+```
+neotest-scala/
+├── lua/neotest-scala/
+│   ├── init.lua           # Main adapter implementation
+│   ├── framework.lua      # Test library registry
+│   ├── utils.lua          # Utility functions
+│   ├── junit.lua          # JUnit XML parsing
+│   └── framework/         # Test library implementations
+│       ├── scalatest.lua
+│       ├── munit.lua
+│       ├── specs2.lua
+│       ├── utest.lua
+│       └── zio-test.lua
+├── test/                  # Test projects for each library
+│   ├── scalatest/
+│   ├── munit/
+│   ├── specs2/
+│   ├── utest/
+│   └── zio-test/
+└── wiki/                  # Documentation
+```
+
+---
+
+## Adding a New Test Library
+
+### Step 1: Create the Framework Module
+
+Create `lua/neotest-scala/framework/mylibrary.lua`:
+
+```lua
+local utils = require("neotest-scala.utils")
+
+---@class neotest-scala.Framework
+local M = {}
+
+--- Builds the sbt command for running tests.
+--- @param project string The sbt project name
+--- @param tree neotest.Tree The test tree
+--- @param name string The test name
+--- @param extra_args table|string Additional arguments
+--- @return string[]
+function M.build_command(project, tree, name, extra_args)
+  local test_namespace = utils.build_test_namespace(tree)
+  
+  if not test_namespace then
+    return vim.tbl_flatten({ "sbt", extra_args, project .. "/test" })
+  end
+  
+  local test_path = ""
+  if tree:data().type == "test" then
+    -- Customize for your library's single test syntax
+    test_path = ' -- -z "' .. name .. '"'
+  end
+  
+  return vim.tbl_flatten({ 
+    "sbt", 
+    extra_args, 
+    project .. "/testOnly " .. test_namespace .. test_path 
+  })
+end
+
+-- Optional: Custom test result matching
+--- @param junit_test table<string, string>
+--- @param position neotest.Position
+--- @return boolean
+function M.match_test(junit_test, position)
+  -- Default matching logic, or implement custom
+  return false
+end
+
+-- Optional: Custom result building
+--- @param junit_test table<string, string>
+--- @param position neotest.Position
+--- @return table<string, any>
+function M.build_test_result(junit_test, position)
+  return {
+    status = junit_test.error_message and TEST_FAILED or TEST_PASSED,
+    errors = junit_test.error_message and {{ message = junit_test.error_message }} or nil,
+  }
+end
+
+return M
+```
+
+### Step 2: Register in framework.lua
+
+Add to `lua/neotest-scala/framework.lua`:
+
+```lua
+function M.get_framework_class(framework)
+  -- ... existing entries ...
+  elseif framework == "mylibrary" then
+    return require(prefix .. "mylibrary")
+  end
+end
+```
+
+### Step 3: Add Detection in utils.lua
+
+Update `utils.get_framework()` to detect your library:
+
+```lua
+function M.get_framework(build_target_info)
+  -- ... existing detection ...
+  or jar:match("(mylibrary)_.*-.*%.jar")
+  -- ...
+end
+```
+
+### Step 4: Add Treesitter Query (if needed)
+
+If your library uses different test syntax, update `init.lua`:
+
+```lua
+function adapter.discover_positions(path)
+  local query = [[
+    -- ... existing patterns ...
+    
+    ;; mylibrary patterns
+    (call_expression
+      function: (identifier) @func_name (#eq? @func_name "mytest")
+      arguments: (arguments (string) @test.name)
+    ) @test.definition
+  ]]
+  -- ...
+end
+```
+
+### Step 5: Create Test Project
+
+Add a test project in `test/mylibrary/`:
+
+```
+test/mylibrary/
+├── build.sbt
+├── project/
+│   └── build.properties
+└── src/test/scala/com/example/
+    └── MyLibraryTest.scala
+```
+
+### Step 6: Add Documentation
+
+Create `wiki/mylibrary.md` with usage examples.
+
+---
+
+## Framework Interface
+
+The `Framework` interface requires:
+
+| Method | Required | Description |
+|--------|----------|-------------|
+| `build_command(project, tree, name, extra_args)` | ✅ | Build the sbt command |
+| `match_test(junit_test, position)` | ❌ | Custom test matching |
+| `build_test_result(junit_test, position)` | ❌ | Custom result building |
+
+---
+
+## Testing Your Changes
+
+### Manual Testing
+
+1. Start Neovim in a test project
+2. Ensure Metals is running
+3. Open a test file
+4. Run `:Neotest summary` to see discovered tests
+5. Run `:Neotest run` to execute tests
+
+### Test with Different Scenarios
+
+- [ ] Single test execution
+- [ ] File-level test execution
+- [ ] Directory-level test execution
+- [ ] Nested test structures
+- [ ] Failing tests (check error reporting)
+- [ ] Debugging with `strategy = 'dap'`
+
+---
+
+## Code Style
+
+- Follow Lua conventions
+- Use 2-space indentation
+- Add type annotations with `---@param` and `---@return`
+- Keep functions small and focused
+
+---
+
+## Pull Request Process
+
+1. **Fork and branch**: Create a feature branch from `main`
+2. **Make changes**: Follow the guidelines above
+3. **Test thoroughly**: Use the test projects
+4. **Update docs**: Add or update wiki pages
+5. **Submit PR**: Describe what you changed and why
+
+### PR Checklist
+
+- [ ] Code follows project style
+- [ ] Changes are tested
+- [ ] Documentation is updated
+- [ ] Commit messages are descriptive
+
+---
+
+## Useful Commands
+
+### Treesitter Inspection
+
+```vim
+" Show the AST for the current file
+:InspectTree
+
+" Show captures for the current query
+:EditQuery
+```
+
+### Debugging the Adapter
+
+```lua
+-- Print discovered positions
+:lua print(vim.inspect(require("neotest-scala").discover_positions("path/to/Test.scala")))
+
+-- Print build target info
+:lua print(vim.inspect(require("neotest-scala.utils").get_build_target_info("/project/root", "/path/to/Test.scala")))
+```
+
+---
+
+## Related Pages
+
+- [[Supported Test Libraries|3.-Supported-Test-Libraries]] — Existing library docs
+- [[Debugging]] — Debug setup for testing
+- [[Troubleshooting]] — Common issues

--- a/wiki/Debugging.md
+++ b/wiki/Debugging.md
@@ -1,0 +1,233 @@
+# Debugging
+
+neotest-scala supports debugging tests with [nvim-dap](https://github.com/mfussenegger/nvim-dap) and [nvim-metals](https://github.com/scalameta/nvim-metals).
+
+## Requirements
+
+| Requirement | Purpose |
+|-------------|---------|
+| **nvim-dap** | Debug Adapter Protocol client for Neovim |
+| **nvim-metals** | Scala LSP with debug capabilities |
+| **Java Debug Server** | Metals handles this automatically |
+
+## Setup
+
+### 1. Install nvim-dap
+
+```lua
+-- lazy.nvim
+{
+  'mfussenegger/nvim-dap',
+  dependencies = {
+    'rcarriga/nvim-dap-ui',  -- Optional: nice UI for debugging
+  },
+}
+```
+
+### 2. Configure nvim-metals with DAP
+
+```lua
+local metals_config = require('metals').bare_config()
+
+-- Enable DAP integration
+metals_config.settings = {
+  enableSemanticHighlighting = true,
+}
+
+-- Auto-attach Metals
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = { "scala", "sbt" },
+  callback = function()
+    require("metals").initialize_or_attach(metals_config)
+  end,
+  group = vim.api.nvim_create_augroup("nvim-metals", { clear = true }),
+})
+```
+
+### 3. Configure nvim-dap for Scala
+
+```lua
+local dap = require('dap')
+
+-- Scala/Java debug configuration
+dap.configurations.scala = {
+  {
+    type = "scala",
+    request = "launch",
+    name = "Run or Test Target",
+    metals = {
+      runType = "runOrTestFile",
+    },
+  },
+}
+```
+
+## Running Tests with Debugger
+
+### Basic Debug Run
+
+```lua
+-- Debug nearest test
+require('neotest').run.run({ strategy = 'dap' })
+
+-- Debug all tests in file
+require('neotest').run.run({ vim.fn.expand('%'), strategy = 'dap' })
+```
+
+### Keymaps Example
+
+```lua
+vim.keymap.set('n', '<leader>td', function()
+  require('neotest').run.run({ strategy = 'dap' })
+end, { desc = "Debug nearest test" })
+```
+
+### Using Command Mode
+
+```vim
+:lua require('neotest').run.run({strategy = 'dap'})
+```
+
+## How It Works
+
+When you run a test with the `dap` strategy, neotest-scala:
+
+1. **Queries Metals** for build target information
+2. **Builds a debug configuration** appropriate for the test type:
+   - **File**: Uses `runType = "testFile"`
+   - **Namespace/Class**: Uses `testClass` parameter
+   - **Individual Test**: Uses `ScalaTestSuitesDebugRequest` with test selectors
+
+3. **Starts the debugger** via nvim-dap
+
+## Debug Configuration by Test Type
+
+### File Level
+
+```lua
+{
+  type = "scala",
+  request = "launch",
+  name = "NeotestScala",
+  metals = {
+    runType = "testFile",
+    path = "/path/to/TestFile.scala",
+  },
+}
+```
+
+### Class/Namespace Level
+
+```lua
+{
+  type = "scala",
+  request = "launch",
+  name = "from_lens",
+  metals = {
+    testClass = "com.example.MyTestSuite",
+  },
+}
+```
+
+### Individual Test
+
+```lua
+{
+  type = "scala",
+  request = "launch",
+  name = "from_lens",
+  metals = {
+    target = { uri = "file:/project-root/?id=project-test" },
+    requestData = {
+      suites = {
+        {
+          className = "com.example.MyTestSuite",
+          tests = { "my test name" },
+        },
+      },
+      jvmOptions = {},
+      environmentVariables = {},
+    },
+  },
+}
+```
+
+## Debugging Support by Library
+
+| Library | Single Test Debug | Class Debug | Notes |
+|---------|-------------------|-------------|-------|
+| ScalaTest | ✅ | ✅ | Full support |
+| munit | ✅ | ✅ | Full support |
+| specs2 | ✅ | ✅ | Full support |
+| utest | ❌ | ✅ | No `TestSelector` implementation |
+| zio-test | ✅ | ✅ | Full support |
+
+### utest Limitation
+
+utest does not implement `sbt.testing.TestSelector`, so individual test debugging is not supported. You can:
+
+1. Debug the entire test suite
+2. Temporarily isolate the test you want to debug
+3. Add breakpoints that catch the right test
+
+## Using with nvim-dap-ui
+
+For a better debugging experience:
+
+```lua
+require("dapui").setup()
+
+-- Auto-open UI on debug
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = "scala",
+  callback = function()
+    local dap = require('dap')
+    local dapui = require('dapui')
+    
+    dap.listeners.after.event_initialized["dapui_config"] = function()
+      dapui.open()
+    end
+    dap.listeners.before.event_terminated["dapui_config"] = function()
+      dapui.close()
+    end
+    dap.listeners.before.event_exited["dapui_config"] = function()
+      dapui.close()
+    end
+  end,
+})
+```
+
+## Troubleshooting Debug Issues
+
+### "No debug adapter found"
+
+Ensure Metals is running and has initialized:
+
+```vim
+:LspInfo
+" Should show metals attached
+```
+
+### "Cannot find main class"
+
+The test may not have compiled. Run tests normally first:
+
+```vim
+:Neotest run
+```
+
+### Breakpoints Not Hit
+
+1. Ensure the code is compiled with debug symbols (default in sbt)
+2. Check that the breakpoint is in the correct file
+3. Try setting the breakpoint after the debug session starts
+
+### utest: Can't Debug Individual Tests
+
+This is a known limitation. Debug at the suite level instead.
+
+## Related Pages
+
+- [[Troubleshooting]] — General issues
+- [[Configuration|2.-Configuration]] — Configuration options
+- [[Supported Test Libraries|3.-Supported-Test-Libraries]] — Library support matrix

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,73 @@
+# neotest-scala Wiki
+
+Welcome to the neotest-scala documentation.
+
+## Quick Links
+
+- [[Installation|1.-Installation]] — Setup with lazy.nvim, packer, or manual
+- [[Configuration|2.-Configuration]] — Args, dynamic configuration, and options
+- [[Supported Test Libraries|3.-Supported-Test-Libraries]] — Overview of all 5 supported libraries
+- [[ScalaTest]] — FunSuite, FreeSpec, AnyFlatSpec patterns
+- [[munit]] — ScalaTest-style syntax with munit
+- [[specs2]] — Mutable Specification patterns
+- [[utest]] — Lightweight testing with utest
+- [[zio-test]] — ZIO's built-in testing framework
+- [[Debugging]] — nvim-dap integration with Metals
+- [[Troubleshooting]] — Common issues and solutions
+- [[Contributing]] — How to add support for new test libraries
+
+## What This Plugin Does
+
+A [Neotest](https://github.com/rcarriga/neotest) adapter for running Scala tests directly from Neovim.
+
+### Features
+
+- **5 Test Libraries Supported**: ScalaTest, munit, specs2, utest, zio-test
+- **Treesitter-based Test Discovery**: Automatically detects tests in your Scala files
+- **Metals Integration**: Uses nvim-metals for project metadata and build target detection
+- **Debugging Support**: Debug tests with nvim-dap integration
+- **Flexible Configuration**: Custom args, dynamic configuration callbacks
+
+### Supported Test Libraries
+
+| Library | Style | Single Test Debug |
+|---------|-------|-------------------|
+| [ScalaTest](ScalaTest) | BDD, FunSuite, FreeSpec | ✅ Yes |
+| [munit](munit) | ScalaTest-style | ✅ Yes |
+| [specs2](specs2) | Specification-based | ✅ Yes |
+| [utest](utest) | Lightweight | ❌ No |
+| [zio-test](zio-test) | ZIO effects | ✅ Yes |
+
+### Quick Example
+
+```lua
+require("neotest").setup({
+  adapters = {
+    require("neotest-scala")
+  }
+})
+```
+
+Then use Neotest commands to run tests:
+
+```vim
+:Neotest run        " Run nearest test
+:Neotest run file   " Run all tests in file
+:Neotest summary    " Open test summary
+```
+
+## Requirements
+
+| Requirement | Purpose |
+|-------------|---------|
+| **Neovim 0.8+** | Core editor |
+| **neotest** | Test runner framework |
+| **nvim-metals** | Scala LSP for project metadata |
+| **sbt** | Build tool for running tests |
+| **Treesitter Scala** | Test discovery |
+
+See [[Installation|1.-Installation]] for detailed setup instructions.
+
+## Fork Notice
+
+This is a fork of the original [neotest-scala](https://github.com/stevanmilic/neotest-scala) by [Stevan Milic](https://github.com/stevanmilic). Huge thanks for creating and maintaining the original plugin.

--- a/wiki/ScalaTest.md
+++ b/wiki/ScalaTest.md
@@ -1,0 +1,153 @@
+# ScalaTest
+
+ScalaTest is the most popular testing library in the Scala ecosystem. neotest-scala supports multiple ScalaTest styles.
+
+## Official Documentation
+
+- Website: [scalatest.org](https://www.scalatest.org/)
+- Getting Started: [scalatest.org/user_guide](https://www.scalatest.org/user_guide/)
+
+## Setup
+
+### build.sbt
+
+```scala
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.18" % Test
+```
+
+## Supported Styles
+
+### AnyFunSuite
+
+The most common style for unit testing:
+
+```scala
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class MySpec extends AnyFunSuite with Matchers {
+  test("addition works") {
+    1 + 1 shouldEqual 2
+  }
+
+  test("multiple assertions") {
+    val result = List(1, 2, 3).sum
+    result shouldEqual 6
+  }
+}
+```
+
+**Detection**: The `test("name") { ... }` syntax is detected by Treesitter.
+
+### AnyFreeSpec
+
+BDD-style with natural language test names:
+
+```scala
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class MySpec extends AnyFreeSpec with Matchers {
+  "A Calculator" - {
+    "should add numbers correctly" in {
+      1 + 1 shouldEqual 2
+    }
+
+    "should handle negative numbers" in {
+      -1 + 1 shouldEqual 0
+    }
+
+    "nested context" - {
+      "with more tests" in {
+        true shouldBe true
+      }
+    }
+  }
+}
+```
+
+**Detection**: The `"name" - { ... }` and `"name" in { ... }` syntax is detected.
+
+### AnyFlatSpec
+
+Classic xUnit-style:
+
+```scala
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class MySpec extends AnyFlatSpec with Matchers {
+  "A Calculator" should "add numbers" in {
+    1 + 1 shouldEqual 2
+  }
+
+  it should "handle subtraction" in {
+    2 - 1 shouldEqual 1
+  }
+}
+```
+
+**Note**: FlatSpec test detection may have limitations due to the infix syntax.
+
+## Test Commands
+
+### Run All Tests in Class
+
+```bash
+sbt <project>/testOnly com.example.MySpec
+```
+
+### Run Single Test
+
+```bash
+sbt <project>/testOnly com.example.MySpec -- -z "addition works"
+```
+
+The `-z` flag filters tests by name substring match.
+
+## Test Discovery
+
+| Syntax | Detected | Example |
+|--------|----------|---------|
+| `test("name") { }` | ✅ | FunSuite style |
+| `"name" in { }` | ✅ | FreeSpec, FlatSpec |
+| `"name" - { }` | ✅ | FreeSpec nesting |
+
+## Debugging
+
+ScalaTest supports debugging individual tests via nvim-dap:
+
+```lua
+require('neotest').run.run({ strategy = 'dap' })
+```
+
+See [[Debugging]] for setup instructions.
+
+## Nested Tests
+
+FreeSpec supports deeply nested test structures:
+
+```scala
+"A Feature" - {
+  "with a sub-feature" - {
+    "and another level" - {
+      "should work" in {
+        assert(true)
+      }
+    }
+  }
+}
+```
+
+All nesting levels are detected and shown in the Neotest summary.
+
+## Limitations
+
+- Test names with special characters (e.g., `-`, `(`, `)`) may have matching issues
+- FlatSpec `should`/`must`/`can` infix syntax detection may be incomplete
+
+## Related Pages
+
+- [[Supported Test Libraries|3.-Supported-Test-Libraries]] — All libraries overview
+- [[Debugging]] — Debugging setup
+- [[Configuration|2.-Configuration]] — Configuration options

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -1,0 +1,239 @@
+# Troubleshooting
+
+Common issues and solutions when using neotest-scala.
+
+## Quick Diagnostics
+
+```vim
+" Check if Metals is running
+:LspInfo
+
+" Check if neotest-scala is loaded
+:lua print(vim.inspect(package.loaded['neotest-scala']))
+
+" Check Treesitter parser
+:TSInstallInfo
+
+" Check test discovery
+:Neotest summary
+```
+
+---
+
+## Common Issues
+
+### "Can't resolve root project folder"
+
+**Symptoms**: Error when running tests
+
+**Cause**: No `build.sbt` file found in parent directories
+
+**Solution**: 
+- Ensure you're in an sbt project with a `build.sbt` file
+- Run tests from within the project directory
+
+---
+
+### "Can't resolve project, has Metals initialised?"
+
+**Symptoms**: Error when trying to run tests
+
+**Cause**: Metals LSP is not running or not yet initialized
+
+**Solution**:
+1. Wait for Metals to initialize (check `:LspInfo`)
+2. If Metals isn't attached, start it manually:
+   ```lua
+   require("metals").initialize_or_attach({})
+   ```
+3. Try again after Metals shows "ready" status
+
+---
+
+### "Failed to detect testing library"
+
+**Symptoms**: Plugin can't determine which test library is in use
+
+**Cause**: Metals hasn't returned build target info, or no known test library in classpath
+
+**Solution**:
+1. Ensure your test library is added to `build.sbt`:
+   ```scala
+   libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.18" % Test
+   ```
+2. Run `sbt update` to download dependencies
+3. Restart Metals with `:MetalsRestartServer`
+4. Try again
+
+---
+
+### Tests Not Discovered
+
+**Symptoms**: No tests appear in Neotest summary
+
+**Causes and Solutions**:
+
+1. **File not named as test file**
+   - Files must contain `test`, `spec`, or `suite` (case-insensitive)
+   - Rename: `MyTests.scala` ✓, `MyClass.scala` ✗
+
+2. **Treesitter parser not installed**
+   ```vim
+   :TSInstall scala
+   ```
+
+3. **Test syntax not recognized**
+   - Check that your test syntax matches supported patterns
+   - See [[Supported Test Libraries|3.-Supported-Test-Libraries]] for syntax details
+
+4. **Compilation errors**
+   - Tests with compilation errors won't be discovered
+   - Fix compilation issues first
+
+---
+
+### Tests Run But Results Don't Show
+
+**Symptoms**: Tests execute but Neotest shows no results
+
+**Causes and Solutions**:
+
+1. **JUnit report not found**
+   - Check that `target/test-reports/` directory exists after running tests
+   - Some test configurations may not generate JUnit XML
+
+2. **Test ID mismatch**
+   - Test names with special characters may not match
+   - Try running the test file instead of individual tests
+
+3. **Compilation failed**
+   - Check the test output for compilation errors
+   ```vim
+   :Neotest output-panel
+   ```
+
+---
+
+### Debug Not Working
+
+**Symptoms**: `strategy = 'dap'` doesn't start debugger
+
+**Causes and Solutions**:
+
+1. **nvim-dap not configured**
+   - Ensure nvim-dap is installed and configured
+   - See [[Debugging]] for setup instructions
+
+2. **Metals debug not enabled**
+   - Ensure Metals is properly configured with debug support
+
+3. **utest single test debugging**
+   - utest doesn't support single test debugging
+   - Debug at the suite level instead
+
+---
+
+### "Compilation failed" Error
+
+**Symptoms**: Tests show compilation failure
+
+**Solutions**:
+1. Run `sbt compile` to see detailed errors
+2. Fix compilation errors in your test code
+3. Check for missing dependencies in `build.sbt`
+
+---
+
+### Slow Test Discovery
+
+**Symptoms**: Long delay before tests appear
+
+**Causes and Solutions**:
+
+1. **Large project**
+   - Metals needs time to index large projects
+   - Wait for indexing to complete
+
+2. **Slow Metals startup**
+   - First run after `sbt clean` is slower
+   - Subsequent runs are faster with BSP caching
+
+---
+
+### Wrong Project Running
+
+**Symptoms**: Tests run in wrong sbt subproject
+
+**Cause**: neotest-scala can't determine which project the file belongs to
+
+**Solution**:
+1. Ensure Metals has indexed all subprojects
+2. Check that source paths are correctly configured in `build.sbt`
+
+---
+
+### Test Results Incorrect
+
+**Symptoms**: Passed tests show as failed, or vice versa
+
+**Causes and Solutions**:
+
+1. **Test name matching issues**
+   - Test names with special characters (`.`, `-`, spaces) may cause matching issues
+   - This is a known limitation in some cases
+
+2. **specs2 naming**
+   - specs2 uses different naming conventions
+   - The adapter normalizes names but edge cases exist
+
+---
+
+## Diagnostic Commands
+
+### Check Metals Status
+
+```vim
+:MetalsStatus
+:MetalsQuickRun
+```
+
+### Check Test Output
+
+```vim
+:Neotest output
+:Neotest output-panel
+```
+
+### Re-run with Verbose Output
+
+```lua
+require('neotest').run.run({ extra_args = { "-v" } })
+```
+
+### Enable Plugin Logging
+
+Add to your config for debugging:
+
+```lua
+-- Temporarily add prints to see what's happening
+vim.notify = function(msg, ...) print(msg) end
+```
+
+---
+
+## Getting Help
+
+1. **Check existing issues**: [GitHub Issues](https://github.com/olisikh/neotest-scala/issues)
+2. **Provide diagnostic info**:
+   - Neovim version: `:version`
+   - Metals status: `:LspInfo`
+   - Test library and version from `build.sbt`
+   - Minimal reproduction case
+
+---
+
+## Related Pages
+
+- [[Debugging]] — Debug setup and issues
+- [[Configuration|2.-Configuration]] — Configuration options
+- [[Supported Test Libraries|3.-Supported-Test-Libraries]] — Library-specific notes

--- a/wiki/munit.md
+++ b/wiki/munit.md
@@ -1,0 +1,151 @@
+# munit
+
+munit is a modern, opinionated testing library from the ScalaMeta team with ScalaTest-style syntax.
+
+## Official Documentation
+
+- Website: [scalameta.org/munit](https://scalameta.org/munit/)
+- Getting Started: [scalameta.org/munit/docs/getting-started.html](https://scalameta.org/munit/docs/getting-started.html)
+
+## Setup
+
+### build.sbt
+
+```scala
+libraryDependencies += "org.scalameta" %% "munit" % "1.0.0" % Test
+```
+
+## Basic Usage
+
+```scala
+class MySuite extends munit.FunSuite {
+  test("addition works") {
+    assertEquals(1 + 1, 2)
+  }
+
+  test("string operations") {
+    val str = "hello"
+    assertEquals(str.length, 5)
+    assert(str.startsWith("he"))
+  }
+}
+```
+
+## Test Discovery
+
+The `test("name") { ... }` syntax is detected by Treesitter:
+
+```scala
+class MySuite extends munit.FunSuite {
+  test("my test") {        // ✅ Detected
+    // test body
+  }
+}
+```
+
+## Test Commands
+
+### Run All Tests in Class
+
+```bash
+sbt <project>/testOnly com.example.MySuite
+```
+
+### Run Single Test
+
+```bash
+sbt <project>/testOnly -- "com.example.MySuite.addition works"
+```
+
+munit uses a hierarchical test path selector for running individual tests.
+
+## Features
+
+### Assertions
+
+```scala
+class AssertionSuite extends munit.FunSuite {
+  test("assertions") {
+    // Equality
+    assertEquals(1 + 1, 2)
+    
+    // Boolean
+    assert(true)
+    assert(!false)
+    
+    // Double with tolerance
+    assertDoubleEquals(1.0, 1.0, 0.001)
+    
+    // Type checking
+    assertTypeEquals(1, 2)  // Compiles only if same type
+  }
+}
+```
+
+### Fixtures
+
+```scala
+class FixtureSuite extends munit.FunSuite {
+  var tempFile: java.io.File = _
+  
+  override def beforeEach(context: BeforeEach): Unit = {
+    tempFile = java.io.File.createTempFile("test", ".tmp")
+  }
+  
+  override def afterEach(context: AfterEach): Unit = {
+    tempFile.delete()
+  }
+  
+  test("use temp file") {
+    assert(tempFile.exists())
+  }
+}
+```
+
+### Async Tests
+
+```scala
+import scala.concurrent.Future
+import munit.FunSuite
+
+class AsyncSuite extends FunSuite {
+  test("async operation") {
+    Future {
+      1 + 1
+    }.map { result =>
+      assertEquals(result, 2)
+    }
+  }
+}
+```
+
+## Debugging
+
+munit supports debugging individual tests:
+
+```lua
+require('neotest').run.run({ strategy = 'dap' })
+```
+
+See [[Debugging]] for setup instructions.
+
+## Test Path Building
+
+neotest-scala builds hierarchical test paths for munit:
+
+| Context | Test Path |
+|---------|-----------|
+| File | `package.*` |
+| Namespace (class) | `package.ClassName` |
+| Test | `package.ClassName.test name` |
+| Nested test | `package.ClassName.parent name.test name` |
+
+## Limitations
+
+- Nested test suites (tests within tests) are supported but path building may be complex
+
+## Related Pages
+
+- [[Supported Test Libraries|3.-Supported-Test-Libraries]] — All libraries overview
+- [[Debugging]] — Debugging setup
+- [[Configuration|2.-Configuration]] — Configuration options

--- a/wiki/specs2.md
+++ b/wiki/specs2.md
@@ -1,0 +1,164 @@
+# specs2
+
+specs2 is a specification-based testing library for Scala that supports both mutable and immutable specification styles.
+
+## Official Documentation
+
+- Website: [etorreborre.github.io/specs2](https://etorreborre.github.io/specs2)
+- Guide: [etorreborre.github.io/specs2/guide](https://etorreborre.github.io/specs2/guide/)
+
+## Setup
+
+### build.sbt
+
+```scala
+libraryDependencies += "org.specs2" %% "specs2-core" % "4.20.3" % Test
+```
+
+## Supported Styles
+
+### mutable.Specification
+
+The mutable style uses `>>` and `in` operators:
+
+```scala
+import org.specs2.mutable.Specification
+
+class MySpec extends Specification {
+  "My Feature" >> {
+    "should work correctly" in {
+      1 mustEqual 1
+    }
+
+    "should handle errors" in {
+      1 must beEqualTo(1)
+    }
+
+    "nested context" >> {
+      "with nested test" in {
+        true must beTrue
+      }
+    }
+  }
+}
+```
+
+### Test Syntax Detection
+
+| Syntax | Detected | Notes |
+|--------|----------|-------|
+| `"name" in { }` | ✅ | Standard test |
+| `"name" >> { }` | ✅ | Alternative syntax |
+| `"name" should { }` | ✅ | BDD-style |
+| `"name" can { }` | ✅ | BDD-style |
+
+## Test Commands
+
+### Run All Tests in Class
+
+```bash
+sbt <project>/testOnly com.example.MySpec
+```
+
+### Run Single Test
+
+```bash
+# Limited support - runs full spec
+sbt <project>/testOnly com.example.MySpec
+```
+
+> **Note**: specs2 has limited support for running individual tests due to framework limitations. The `-- ex` syntax is available but has issues with tests containing brackets or grouped tests.
+
+## Features
+
+### Matchers
+
+```scala
+class MatcherSpec extends Specification {
+  "Matchers" >> {
+    "equality" in {
+      1 mustEqual 1
+      1 must beEqualTo(1)
+      1 === 1
+    }
+
+    "comparison" in {
+      1 must beLessThan(2)
+      1 must beGreaterThan(0)
+    }
+
+    "collections" in {
+      List(1, 2, 3) must contain(2)
+      List(1, 2, 3) must haveSize(3)
+    }
+
+    "strings" in {
+      "hello" must startWith("he")
+      "hello" must endWith("lo")
+      "hello" must contain("ell")
+    }
+  }
+}
+```
+
+### Data Tables
+
+```scala
+class TableSpec extends Specification {
+  "addition" >> {
+    val table = 
+      "a" | "b" | "result" |
+       1  !  2  !    3     |
+       2  !  3  !    5     |
+       5  !  5  !   10     |> { (a, b, expected) =>
+        a + b mustEqual expected
+      }
+  }
+}
+```
+
+## Debugging
+
+specs2 supports debugging individual tests:
+
+```lua
+require('neotest').run.run({ strategy = 'dap' })
+```
+
+See [[Debugging]] for setup instructions.
+
+## Test Matching
+
+neotest-scala uses custom matching logic for specs2:
+
+```lua
+-- Test ID normalization handles specs2's naming:
+-- "test should::be awesome" → "test.should.be.awesome"
+```
+
+The adapter strips `should::`, `must::` prefixes and converts `::` to `.` for matching.
+
+## Known Limitations
+
+1. **Single Test Execution**: Running individual tests is limited. Tests with brackets or grouped tests may not run in isolation.
+
+2. **String-based Specifications**: The `s2"""` string interpolation style is **not supported** due to Treesitter limitations. Use the mutable `Specification` style instead.
+
+   ```scala
+   // NOT supported (string-based)
+   override def is = s2"""
+     This is a test $e1
+   """
+   def e1 = 1 mustEqual 1
+
+   // Supported (mutable style)
+   "This is a test" in {
+     1 mustEqual 1
+   }
+   ```
+
+## Related Pages
+
+- [[Supported Test Libraries|3.-Supported-Test-Libraries]] — All libraries overview
+- [[Debugging]] — Debugging setup
+- [[Configuration|2.-Configuration]] — Configuration options

--- a/wiki/utest.md
+++ b/wiki/utest.md
@@ -1,0 +1,190 @@
+# utest
+
+utest is a lightweight, minimal testing library for Scala by Li Haoyi.
+
+## Official Documentation
+
+- GitHub: [github.com/com-lihaoyi/utest](https://github.com/com-lihaoyi/utest)
+- Documentation: [lihaoyi.github.io/utest](https://lihaoyi.github.io/utest/)
+
+## Setup
+
+### build.sbt
+
+```scala
+libraryDependencies += "com.lihaoyi" %% "utest" % "0.8.3" % Test
+testFrameworks += new TestFramework("utest.runner.Framework")
+```
+
+> **Note**: utest requires both the dependency AND the test framework registration.
+
+## Basic Usage
+
+```scala
+package com.example
+
+import utest._
+
+object MyTests extends TestSuite {
+  val tests = Tests {
+    test("addition works") {
+      1 + 1 ==> 2
+    }
+
+    test("string operations") {
+      val str = "hello"
+      assert(str.length == 5)
+      str ==> "hello"
+    }
+
+    test("failing example") {
+      1 + 1 ==> 3  // This will fail
+    }
+  }
+}
+```
+
+## Test Discovery
+
+The `test("name") { ... }` syntax inside a `Tests { }` block is detected:
+
+```scala
+object MyTests extends TestSuite {
+  val tests = Tests {
+    test("my test") {       // ✅ Detected
+      // test body
+    }
+  }
+}
+```
+
+## Test Commands
+
+### Run All Tests in Object
+
+```bash
+sbt <project>/testOnly com.example.MyTests
+```
+
+### Run Single Test
+
+```bash
+sbt <project>/testOnly -- "com.example.MyTests.addition works"
+```
+
+utest uses a hierarchical test path selector similar to munit.
+
+## Features
+
+### Assertions
+
+```scala
+object AssertionTests extends TestSuite {
+  val tests = Tests {
+    test("arrow assertion") {
+      // ==> asserts equality with nice diff output
+      1 + 1 ==> 2
+    }
+
+    test("boolean assert") {
+      assert(true)
+      assert(1 == 1)
+    }
+
+    test("intercept") {
+      intercept[RuntimeException] {
+        throw new RuntimeException("boom")
+      }
+    }
+  }
+}
+```
+
+### Nested Tests
+
+```scala
+object NestedTests extends TestSuite {
+  val tests = Tests {
+    test("outer") {
+      test("inner 1") {
+        1 ==> 1
+      }
+      test("inner 2") {
+        2 ==> 2
+      }
+    }
+  }
+}
+```
+
+## Debugging Limitation
+
+> ⚠️ **Important**: utest **does not support debugging individual tests**
+
+utest doesn't implement `sbt.testing.TestSelector`, which Metals requires for debugging specific tests.
+
+**Workarounds**:
+1. Debug at the suite level (run the whole test object)
+2. Temporarily comment out other tests
+3. Use a different test library for debugging-intensive work
+
+```lua
+-- This will debug the entire test suite, not just one test
+require('neotest').run.run({ strategy = 'dap' })
+```
+
+## Test Path Building
+
+| Context | Test Path |
+|---------|-----------|
+| File | `package.{TestSuite1,TestSuite2}` |
+| Object (namespace) | `package.ObjectName` |
+| Test | `package.ObjectName.test name` |
+| Nested test | `package.ObjectName.outer.inner` |
+
+## Running Multiple Suites
+
+When running at the file or directory level, utest can run multiple test suites:
+
+```bash
+# Runs all test objects in the file
+sbt <project>/testOnly com.example.*
+
+# Runs all tests in a package
+sbt <project>/testOnly com.example.{Test1,Test2,Test3}
+```
+
+## Tips
+
+### Use `==>` for Better Error Messages
+
+```scala
+test("prefer arrow") {
+  // Better - shows diff on failure
+  computeValue() ==> expectedValue
+  
+  // Worse - generic assertion error
+  assert(computeValue() == expectedValue)
+}
+```
+
+### Group Related Tests
+
+```scala
+val tests = Tests {
+  test("feature A") {
+    test("case 1") { ... }
+    test("case 2") { ... }
+  }
+  
+  test("feature B") {
+    test("case 1") { ... }
+  }
+}
+```
+
+## Related Pages
+
+- [[Supported Test Libraries|3.-Supported-Test-Libraries]] — All libraries overview
+- [[Debugging]] — Debugging (note: utest limitations)
+- [[Configuration|2.-Configuration]] — Configuration options

--- a/wiki/zio-test.md
+++ b/wiki/zio-test.md
@@ -1,0 +1,257 @@
+# zio-test
+
+zio-test is ZIO's built-in testing framework, designed for testing effectful programs.
+
+## Official Documentation
+
+- Website: [zio.dev/reference/test](https://zio.dev/reference/test/)
+- Guide: [zio.dev/reference/test/overview](https://zio.dev/reference/test/overview)
+
+## Setup
+
+### build.sbt
+
+```scala
+libraryDependencies ++= Seq(
+  "dev.zio" %% "zio" % "2.1.0",
+  "dev.zio" %% "zio-test" % "2.1.0" % Test,
+  "dev.zio" %% "zio-test-sbt" % "2.1.0" % Test
+)
+testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
+```
+
+> **Note**: zio-test requires both the library and the sbt test framework registration.
+
+## Basic Usage
+
+### ZIOSpecDefault
+
+```scala
+package com.example
+
+import zio.{test => _, _}
+import zio.test._
+import zio.test.Assertion._
+
+object MySpec extends ZIOSpecDefault {
+  def spec = suite("MySuite")(
+    test("addition works") {
+      for {
+        result <- ZIO.succeed(1 + 1)
+      } yield assertTrue(result == 2)
+    },
+
+    test("simple assertion") {
+      assertTrue(1 + 1 == 2)
+    }
+  )
+}
+```
+
+### suiteAll
+
+An alternative syntax for simpler test definitions:
+
+```scala
+package com.example
+
+import zio.{test => _, _}
+import zio.test._
+
+object MySuiteAllSpec extends ZIOSpecDefault {
+  def spec = suiteAll("MySuite") {
+    test("first test") {
+      assertTrue(1 == 1)
+    }
+
+    test("second test") {
+      for {
+        value <- ZIO.succeed(42)
+      } yield assertTrue(value == 42)
+    }
+
+    suite("nested suite") {
+      test("nested test") {
+        assertTrue(true)
+      }
+    }
+  }
+}
+```
+
+## Test Discovery
+
+| Syntax | Detected | Example |
+|--------|----------|---------|
+| `test("name") { }` | ✅ | Standard test |
+| `suite("name") { }` | ✅ | Test suite |
+| `suiteAll("name") { }` | ✅ | Alternative suite |
+
+## Test Commands
+
+### Run All Tests in Object
+
+```bash
+sbt <project>/testOnly com.example.MySpec
+```
+
+### Run Single Test
+
+```bash
+sbt <project>/testOnly com.example.MySpec -- -t "addition works"
+```
+
+The `-t` flag filters tests by exact name match.
+
+## Assertions
+
+### assertTrue (Recommended)
+
+```scala
+test("modern assertions") {
+  val value = 42
+  assertTrue(value == 42)
+  assertTrue(value > 0)
+  assertTrue(value < 100)
+}
+```
+
+### Legacy Assertions
+
+```scala
+test("legacy assertions") {
+  for {
+    value <- ZIO.succeed(Some(42))
+  } yield assert(value)(isSome(equalTo(42)))
+}
+
+test("collection assertions") {
+  val list = List(1, 2, 3)
+  assert(list)(hasSize(equalTo(3)))
+}
+```
+
+## ZIO-Specific Features
+
+### Testing ZIO Effects
+
+```scala
+test("effect testing") {
+  for {
+    result <- ZIO.attempt(1 / 1)
+  } yield assertTrue(result == 1)
+}
+
+test("testing failures") {
+  val effect = ZIO.fail("error")
+  assertZIO(effect.exit)(fails(equalTo("error")))
+}
+```
+
+### Test Services (Environment)
+
+```scala
+object ServiceSpec extends ZIOSpecDefault {
+  def spec = suite("with test services") {
+    test("use mocked service") {
+      for {
+        result <- MyService.doSomething
+      } yield assertTrue(result == "mocked")
+    }
+  }.provide(
+    MyService.test // Test implementation
+  )
+}
+```
+
+### TestClock
+
+```scala
+test("time-based effects") {
+  for {
+    fiber <- ZIO.sleep(1.hour).fork
+    _     <- TestClock.adjust(1.hour)
+    _     <- fiber.join
+  } yield assertTrue(true)
+}
+```
+
+## Debugging
+
+zio-test supports debugging individual tests:
+
+```lua
+require('neotest').run.run({ strategy = 'dap' })
+```
+
+See [[Debugging]] for setup instructions.
+
+## Nested Tests
+
+zio-test supports deeply nested test structures:
+
+```scala
+def spec = suite("outer")(
+  suite("middle")(
+    suite("inner")(
+      test("deep test") {
+        assertTrue(true)
+      }
+    )
+  )
+)
+```
+
+All nesting levels are detected and shown in the Neotest summary.
+
+## Result Parsing
+
+neotest-scala has custom result parsing for zio-test:
+
+- Parses zio-test's specific JUnit XML output format
+- Extracts error line numbers from stack traces
+- Handles the `-` / `x` prefix notation in test output
+
+## Tips
+
+### Use assertTrue for Better Errors
+
+```scala
+// Preferred - clear failure messages
+assertTrue(complexValue == expected)
+
+// Less preferred - generic assertion failure
+assert(complexValue)(equalTo(expected))
+```
+
+### Group Tests by Feature
+
+```scala
+def spec = suite("UserRepository")(
+  suite("create")(
+    test("creates a new user") { ... },
+    test("validates input") { ... }
+  ),
+  suite("delete")(
+    test("removes existing user") { ... }
+  )
+)
+```
+
+### Provide Test Layers
+
+```scala
+def spec = suite("integration tests") {
+  test("database operation") {
+    for {
+      result <- Database.query
+    } yield assertTrue(result.nonEmpty)
+  }
+}.provideLayer(Database.test)
+```
+
+## Related Pages
+
+- [[Supported Test Libraries|3.-Supported-Test-Libraries]] — All libraries overview
+- [[Debugging]] — Debugging setup
+- [[Configuration|2.-Configuration]] — Configuration options


### PR DESCRIPTION
## Summary

Adds comprehensive wiki documentation for neotest-scala following the pattern from scala-hints.nvim.

## Changes

### GitHub Workflow
- `.github/workflows/sync-wiki.yml` - Auto-syncs wiki/ directory to GitHub Wiki

### Wiki Pages (13 files)

| Page | Description |
|------|-------------|
| Home | Overview, quick links, features summary |
| 1. Installation | Requirements, lazy.nvim/packer/vim-plug setup |
| 2. Configuration | Args, dynamic configuration, command building |
| 3. Supported Test Libraries | Overview of all 5 libraries with comparison table |
| ScalaTest | FunSuite, FreeSpec, AnyFlatSpec patterns |
| munit | Test suite syntax and features |
| specs2 | Mutable Specification patterns, limitations |
| utest | Lightweight testing, debugging limitation |
| zio-test | ZIOSpecDefault, suiteAll patterns |
| Debugging | nvim-dap integration, per-library support |
| Troubleshooting | Common issues and solutions |
| Contributing | How to add new test library support |

## Commits

```
f001a5f ci: add wiki sync workflow
6748505 wiki: add Home page with overview and quick links
d46f5bf wiki: add Installation page with setup instructions
d6fee2c wiki: add Configuration page with args and options
bb42dd1 wiki: add Supported Test Libraries overview page
9d24d30 wiki: add test library pages (ScalaTest, munit, specs2, utest, zio-test)
f0129b4 wiki: add Debugging, Troubleshooting, and Contributing pages
```

## How to Use

1. Merge this PR
2. Ensure GitHub Wiki is enabled in repository settings
3. The sync workflow will automatically copy wiki/ contents to the GitHub Wiki